### PR TITLE
[v3.0.0]Update jwt -> refresh token + access token

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -13,6 +13,10 @@ const userSchema = new mongoose.Schema({
         type: String,
         required: true
     },
+    refreshToken: {
+        type: String,
+        default: null
+    }
 });
 
 userSchema.pre('save', async function (next) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "bcryptjs": "^2.4.3",
+                "cookie-parser": "^1.4.7",
                 "cors": "^2.8.5",
                 "dotenv": "^8.2.0",
                 "express": "^4.17.1",
@@ -199,6 +200,26 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
             "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-parser": {
+            "version": "1.4.7",
+            "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+            "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+            "dependencies": {
+                "cookie": "0.7.2",
+                "cookie-signature": "1.0.6"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/cookie-parser/node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
             "engines": {
                 "node": ">= 0.6"
             }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     },
     "dependencies": {
         "bcryptjs": "^2.4.3",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^8.2.0",
         "express": "^4.17.1",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -5,7 +5,8 @@ const router = express.Router();
 const dotenv = require('dotenv');
 dotenv.config();
 
-const SECRET_KEY = process.env.SECRET_KEY;
+const ACCESS_SECRET_KEY = process.env.ACCESS_SECRET_KEY;
+const REFRESH_SECRET_KEY = process.env.REFRESH_SECRET_KEY;
 
 // 회원가입 라우터
 router.post('/register', async (req, res) => {
@@ -38,12 +39,46 @@ router.post('/login', async (req, res) => {
             return res.status(401).json({ message: '아이디 또는 비밀번호가 잘못되었습니다.' });
         }
 
-        // HS256 알고리즘을 사용하여 토큰 생성
-        const token = jwt.sign({ id: user._id, username }, SECRET_KEY, { expiresIn: '1h', algorithm: 'HS256' });
-        res.json({ token });
+        // Access Token 생성
+        const accessToken = jwt.sign({ id: user._id, username }, ACCESS_SECRET_KEY, { expiresIn: '15m', algorithm: 'HS256' });
+
+        // Refresh Token 생성
+        const refreshToken = jwt.sign({ id: user._id, username }, REFRESH_SECRET_KEY, { expiresIn: '7d', algorithm: 'HS256' });
+        user.refreshToken = refreshToken;
+        await user.save();
+
+        // Refresh Token을 쿠키에 저장
+        res.cookie('refreshToken', refreshToken, {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === 'production', // 프로덕션 환경에서는 true로 설정
+            maxAge: 7 * 24 * 60 * 60 * 1000, // 7일
+        });
+
+        res.json({ accessToken });
     } catch (error) {
         res.status(500).json({ message: '로그인 실패', error: error.message });
     }
+});
+
+// Refresh Token을 사용하여 Access Token 재발급
+router.post('/token', async (req, res) => {
+    const token = req.cookies.refreshToken; // 쿠키에서 refresh token 가져오기
+    if (!token) return res.status(401).json({ message: 'Refresh Token이 없습니다.' });
+
+    const user = await User.findOne({ refreshToken: token });
+    if (!user) return res.status(403).json({ message: '유효하지 않은 Refresh Token입니다.' });
+
+    jwt.verify(token, REFRESH_SECRET_KEY, (err, userData) => {
+        if (err) {
+            // Refresh Token이 만료된 경우
+            if (err.name === 'TokenExpiredError') {
+                return res.status(403).json({ message: 'Refresh Token이 만료되었습니다. 다시 로그인 해주세요.' });
+            }
+            return res.status(403).json({ message: '유효하지 않은 Refresh Token입니다.' });
+        }
+        const accessToken = jwt.sign({ id: userData.id, username: userData.username }, ACCESS_SECRET_KEY, { expiresIn: '15m' });
+        res.json({ accessToken });
+    });
 });
 
 // 인증 미들웨어
@@ -51,7 +86,7 @@ const authenticateToken = (req, res, next) => {
     const token = req.headers['authorization'];
     if (!token) return res.status(401).json({ message: '토큰이 없습니다.' });
 
-    jwt.verify(token, SECRET_KEY, { algorithms: ['HS256'] }, (err, user) => {
+    jwt.verify(token, ACCESS_SECRET_KEY, { algorithms: ['HS256'] }, (err, user) => {
         if (err) return res.status(403).json({ message: '유효하지 않은 토큰입니다.' });
         req.user = user;
         next();

--- a/routes/diary.js
+++ b/routes/diary.js
@@ -137,7 +137,7 @@ router.delete("/delete_comment", authenticateToken, async (req, res) => {
         // 댓글 작성자가 요청한 사용자와 일치하는지 확인
         const comment = diary.comments[index];
         if (comment.username !== username) {
-            return res.status(403).json({ message: "댓글을 삭제할 권한이 없습니다." });
+            return res.status(401).json({ message: "댓글을 삭제할 권한이 없습니다." });
         }
 
         // 댓글 삭제

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const cookieParser = require('cookie-parser');
 const mongoose = require('mongoose');
 const dotenv = require('dotenv');
 const cors = require('cors');
@@ -20,8 +21,11 @@ const HOST = process.env.HOST;
 app.use(express.json({
   limit : "1mb"
 }));
-app.use(cors()); // CORS 미들웨어 사용
-
+app.use(cors({
+  origin: 'https://hesuhesu.o-r.kr:3000', // 프론트엔드 도메인
+  credentials: true, // 쿠키 전달을 허용
+}));
+app.use(cookieParser());
 app.use(express.urlencoded({
   limit:"1mb",
   extended: false

--- a/server_backup.js
+++ b/server_backup.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const cookieParser = require('cookie-parser');
 const mongoose = require('mongoose');
 const dotenv = require('dotenv');
 const cors = require('cors');
@@ -20,8 +21,11 @@ const HOST = process.env.HOST;
 app.use(express.json({
   limit : "1mb"
 }));
-app.use(cors()); // CORS 미들웨어 사용
-
+app.use(cors({
+  origin: 'https://hesuhesu.o-r.kr:3000', // 프론트엔드 도메인
+  credentials: true, // 쿠키 전달을 허용
+}));
+app.use(cookieParser());
 app.use(express.urlencoded({
   limit:"1mb",
   extended: false


### PR DESCRIPTION
# Update jwt -> refresh token + access token

<br>

**1. Update jwt**
- 기존의 jwt 인증 방식은 access token 만 존재했음. 사용자 경험을 저해하고 불편함을 야기함.
- 개선하기 위해 refresh token 과 access token 을 요청받도록 구성함.
- login logic 과 comment logic 에서 refresh token 은 cookie 값으로 받도록 적용
- access token 은 localstorage 에 저장하며 15분 간 토큰이 유지되고 이후에는 자동 폐기됨

<br>

# ToDo

1. admin dashboard 구현하여 관리자만의 권한을 부여하도록 할 예정
2. 기타 ui 개편